### PR TITLE
fix meta tools version log

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,11 @@ function initApp(callback) {
     });
     let versionFile = c.meta.broker.mappings.dir.split('broker/')[0].concat(c.meta.versionFile);
     fs.readFile(versionFile, 'utf8', function (err, data) {
-      debug('meta tools version: %s', data.trim());
+      if (err) {
+        debug('could not read meta tools version: %s', err);
+      } else {
+        debug('meta tools version: %s', data.trim());
+      }
     })
 
     app.listen(c.net.port, () => {


### PR DESCRIPTION
Version log was missing error handling, which resulted in the muncher breaking down immediately after startup.
Failed to read versionFile. Added `if (err) { ... } else { ... }` (lines 242 ff.)